### PR TITLE
Fix type mismatch compilation error

### DIFF
--- a/src/gnss_location.toit
+++ b/src/gnss_location.toit
@@ -70,5 +70,5 @@ class GnssLocation extends Location:
 
   /** The hash code. */
   hash_code -> int:
-    return super + time.hash_code * 19 + horizontal_accuracy * 23
-        + vertical_accuracy * 29 + horizontal_accuracy * 37 + altitude_msl * 41
+    return (super + time.hash_code * 19 + horizontal_accuracy * 23
+        + vertical_accuracy * 29 + horizontal_accuracy * 37 + altitude_msl * 41).to_int


### PR DESCRIPTION
After the `horizontal_accuracy`, `vertical_accuracy` and `altitude_msl` got typed as floats in toitware/toit-gnss-location#2 I get an compilation error in the `hash_code` function for type mismatch
```
<pkg:toit-gnss-location>/gnss_location.toit:73:5: error: Type mismatch. Expected 'int'. Got 'float'
    return super + time.hash_code * 19 + horizontal_accuracy * 23
    ^~~~~~
Compilation failed.
```

I'm new to the toit ecosystem 🤷🏻‍♂️ so all guidance is appreciated!